### PR TITLE
Remove deprecated conn.start() method call

### DIFF
--- a/bmrs.py
+++ b/bmrs.py
@@ -83,8 +83,6 @@ def connect_to_api(api_key, listener, client_id="", port=61613):
         host_and_ports=[("api.bmreports.com", port)], use_ssl=True
     )
     conn.set_listener("", MyListener(conn, listener, api_key, client_id))
-    # attemp a connect
-    conn.start()
 
     while True:
         ## parts that can be moved to inside the loop


### PR DESCRIPTION
Hi there, attempting to use this wrapper and came across an attribute error for the .start() method on the stomp Connection12 object. It appears to be deprecated (https://github.com/jasonrbriggs/stomp.py/commit/7648ef770b6ec4691fab552085461b96c728f487#diff-a321532c6049b67a85eedf10dcd085948fcd4b17f04fbb89469f28cd69bddf47).

Cheers